### PR TITLE
Add TEDDYBANG token info JSON

### DIFF
--- a/src/tokens/smartchain/0x914a01B16A6FB6AFF7eA66B1D621A0082CDaB5Ee
+++ b/src/tokens/smartchain/0x914a01B16A6FB6AFF7eA66B1D621A0082CDaB5Ee
@@ -1,0 +1,8 @@
+{
+  "name": "TEDDYBANG",
+  "symbol": "TEDDYBANG",
+  "address": "0x914a01B16A6FB6AFF7eA66B1D621A0082CDaB5Ee",
+  "chainId": 56,
+  "decimals": 18,
+  "logoURI": "https://raw.githubusercontent.com/ialgausa/teddybang-logo-/main/blockchains/smartchain/assets/0x914a01b16a6fb6aff7ea66b1d621a0082cdab5ee/logo.png"
+}


### PR DESCRIPTION
This commit adds the TEDDYBANG (TEDDYBANG) token to the PancakeSwap token list for visibility on PancakeSwap interfaces. Includes token name, symbol, address, decimals, chain ID (56), and logo URI.